### PR TITLE
Make Docker image run as nobody user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM golang:1.19.2 as builder
+FROM golang:1.21.0 as builder
+
 WORKDIR /src
+
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 
@@ -17,6 +19,10 @@ RUN go build -o /tmp/snyk_exporter
 
 FROM scratch
 
-ENTRYPOINT [ "/snyk_exporter" ]
+COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /tmp/snyk_exporter /
+
+USER 65534
+
+ENTRYPOINT ["/snyk_exporter"]


### PR DESCRIPTION
This PR makes the exporter to run as `nobody`. This will allow to set strict `securityContext` on the Kubernetes Pod.